### PR TITLE
fixed metaphone UnicodeDecodeError in python 3

### DIFF
--- a/src/fuzzy.pyx
+++ b/src/fuzzy.pyx
@@ -243,6 +243,8 @@ cdef class DMetaphone:
     def __call__(self, s):
         cdef char *cs
         cdef char **out
+        cdef bytes o1
+        cdef bytes o2
         out = <char **>malloc(sizeof(char *) * 2)
         cs = s
         DoubleMetaphone(cs, out)


### PR DESCRIPTION
In python3 DMetaphone causes a UnicodeDecodeError.  Try:
`from fuzzy import DMetaphone`
`m = DMetaphone()`
`m("mayer")`
